### PR TITLE
Added pin names to target.json file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,2 @@
-## yotta Target Description using GCC to compile for Nordic nRF51822 16KB device.
+## yotta Target Description using ARMCC to compile for Nordic nRF51822 16KB device.
 

--- a/target.json
+++ b/target.json
@@ -20,7 +20,83 @@
     "mkit"
   ],
   "private" : true,
-  "config": {},
+  "config": {
+    "hardware": {
+      "pins": {
+        "P0_0": "p0",
+        "P0_1": "p1",
+        "P0_2": "p2",
+        "P0_3": "p3",
+        "P0_4": "p4",
+        "P0_5": "p5",
+        "P0_6": "p6",
+        "P0_7": "p7",
+
+        "P0_8": "p8",
+        "P0_9": "p9",
+        "P0_10": "p10",
+        "P0_11": "p11",
+        "P0_12": "p12",
+        "P0_13": "p13",
+        "P0_14": "p14",
+        "P0_15": "p15",
+
+        "P0_16": "p16",
+        "P0_17": "p17",
+        "P0_18": "p18",
+        "P0_19": "p19",
+        "P0_20": "p20",
+        "P0_21": "p21",
+        "P0_22": "p22",
+        "P0_23": "p23",
+
+        "P0_24": "p24",
+        "P0_25": "p25",
+        "P0_26": "p26",
+        "P0_27": "p27",
+        "P0_28": "p28",
+        "P0_29": "p29",
+        "P0_30": "p30",
+
+        "LED1": "p18",
+        "LED2": "p19",
+        "LED3": "p18",
+        "LED4": "p19",
+
+        "BUTTON1": "p16",
+        "BUTTON2": "p17",
+
+        "RX_PIN_NUMBER": "p11",
+        "TX_PIN_NUMBER": "p9",
+        "CTS_PIN_NUMBER": "p10",
+        "RTS_PIN_NUMBER": "p8",
+
+        "USBTX": "TX_PIN_NUMBER",
+        "USBRX": "RX_PIN_NUMBER",
+
+        "SPI_PSELMOSI0": "p20",
+        "SPI_PSELMISO0": "p22",
+        "SPI_PSELSS0": "p24",
+        "SPI_PSELSCK0": "p25",
+
+        "SPI_PSELMOSI1": "p12",
+        "SPI_PSELMISO1": "p13",
+        "SPI_PSELSS1": "p14",
+        "SPI_PSELSCK1": "p15",
+
+        "SPIS_PSELMOSI": "p12",
+        "SPIS_PSELMISO": "p13",
+        "SPIS_PSELSS": "p14",
+        "SPIS_PSELSCK": "p15",
+
+        "I2C_SDA0": "p22",
+        "I2C_SCL0": "p20",
+
+        "I2C_SDA1": "p13",
+        "I2C_SCL1": "p15"
+      }
+    }
+  },
   "scripts": {
     "debug": [
       "valinor",


### PR DESCRIPTION
Added the target specifi pin names to this target. The chip specific
definitions are in yotta module mbed-hal-nrf51822-mcu.
