### PR TITLE
Config - add nvic vtor custom

### DIFF
--- a/target.json
+++ b/target.json
@@ -51,6 +51,11 @@
         "I2C_SDA1": "p13",
         "I2C_SCL1": "p15"
       }
+    },
+    "cmsis": {
+      "nvic": {
+        "has_custom_vtor": true
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
Cmsis-core needs this config as NRF51 implements own non-generic SetVector/GetVector.

Can you please send the same PR to the rest of the nrf51xx targets? We dont have yet the family target which all these inherits? If we do, this changeset should go there and all the targets would just inherit it. But I did not spot any parent for this target besides mbed-armcc.

@rgrover @andresag01 
